### PR TITLE
Use no-shared to stop getting libcrypto and libssl linked dependencies

### DIFF
--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -110,7 +110,8 @@ class Compiler
               elsif @options[:debug]
                 ' -DRUBY_DEBUG -fPIC -g -O0 -pipe '
               else
-                ' -DRUBY_DEBUG -fPIC -O3 -fno-fast-math -ggdb3 -Os -fdata-sections -ffunction-sections -pipe -Wno-error=implicit-function-declaration '
+                #' -DRUBY_DEBUG -fPIC -O3 -fno-fast-math -ggdb3 -Os -fdata-sections -ffunction-sections -pipe -Wno-error=implicit-function-declaration '
+                ' -fPIC -O3 -fno-fast-math -Os -fdata-sections -ffunction-sections -pipe -Wno-error=implicit-function-declaration '
               end
 
     # install prefix for stuffed libraries
@@ -570,7 +571,7 @@ class Compiler
         @utils.run(compile_env,
                    './Configure',
                    'darwin64-arm64-cc',
-                   'shared',
+                   'no-shared',
                    'enable-rc5',
                    'zlib',
                    'no-asm',
@@ -583,7 +584,7 @@ class Compiler
                    'perl',
                    'Configure',
                    'linux-aarch64',
-                   'shared',
+                   'no-shared',
                    "--openssldir=#{@options[:openssl_dir]}",
                    "--prefix=#{@local_build}")
         @utils.run(compile_env, "make #{@options[:nmake_args]}")


### PR DESCRIPTION
I set the compile options to no-shared. It looks like this removed the dependencies. The executable runs on my machine, but I need to do more testing.

### Before
```
otool -L /Users/ebeland/apps/ruby-packer/rubyc
/Users/ebeland/apps/ruby-packer/rubyc:
/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
/var/folders/s9/mtk8pgj529j4lq_b7bl2fkkc0000gn/T/rubyc/local/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
/var/folders/s9/mtk8pgj529j4lq_b7bl2fkkc0000gn/T/rubyc/local/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
/usr/lib/libutil.dylib (compatibility version 1.0.0, current version 1.0.0)
```


### After

```
otool -L /Users/ebeland/apps/ruby-packer/rubyc
/Users/ebeland/apps/ruby-packer/rubyc:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libutil.dylib (compatibility version 1.0.0, current version 1.0.0)
```

----------------------

I also turned off some debug settings to see if we could get a little smaller executable. It works, but the difference isn't major.


